### PR TITLE
Add trace guard to stop players from touching missiles/grenades when moving

### DIFF
--- a/src/jump_types.cpp
+++ b/src/jump_types.cpp
@@ -1,5 +1,6 @@
 
 #include "jump_types.h"
+#include "jump.h"
 
 namespace Jump
 {
@@ -45,5 +46,51 @@ namespace Jump
     bool store_buffer_t::HasStore()
     {
         return numStores > 0;
+    }
+
+    //
+    // playertracetouch_guard_t
+    //
+    playertracetouch_guard_t::playertracetouch_guard_t(const edict_t* ignore_player)
+    {
+        ents.reserve(globals.num_edicts);
+        
+        // Collect all entities that this player should not interact with.
+        for (int i = 0; i < globals.num_edicts; ++i)
+        {
+            auto ent = &(g_edicts[i]);
+
+            if (!ent->inuse || ent == ignore_player)
+                continue;
+
+            // Already not solid.
+            if (ent->solid == SOLID_NOT)
+                continue;
+
+            // Must be moving missile (rockets, blaster)
+            // or bouncey boys (grenades)
+            if (ent->movetype != MOVETYPE_FLYMISSILE && ent->movetype != MOVETYPE_BOUNCE)
+                continue;
+
+            // They are the owner, it should not collide with this player.
+            if (ignore_player == ent->owner)
+                continue;
+
+            ents.push_back({ent, ent->solid});
+
+            ent->solid = SOLID_NOT;
+        }
+    }
+
+    void playertracetouch_guard_t::Free()
+    {
+        for (auto& data : ents)
+        {
+            assert(data.ent->inuse && data.ent->solid == SOLID_NOT);
+
+            data.ent->solid = data.prev_solidtype;
+        }
+
+        ents.resize(0);
     }
 }

--- a/src/jump_types.h
+++ b/src/jump_types.h
@@ -240,4 +240,31 @@ namespace Jump
         // Links the username_key (all lowercase) to the display username
         std::unordered_map<username_key, std::string> all_local_usernames; // TODO!! calc when doing maptimes
     };
+
+    // A convenient way of stopping missiles from interacting
+    // with this player entity through traces.
+    class playertracetouch_guard_t
+    {
+    public:
+        playertracetouch_guard_t(const edict_t* ent);
+
+        ~playertracetouch_guard_t()
+        {
+            Free();
+        }
+
+    private:
+        void Free();
+
+
+        struct guard_data_t
+        {
+            edict_t* ent;
+            solid_t prev_solidtype;
+        };
+
+        // List of entities that were changed and will get reset back
+        // once this object is freed.
+        std::vector<guard_data_t> ents;
+    };
 }

--- a/src/p_client.c
+++ b/src/p_client.c
@@ -1077,8 +1077,16 @@ void ClientThink (edict_t *ent, usercmd_t *ucmd)
 	pm.trace = PM_trace;	// adds default parms
 	pm.pointcontents = gi.pointcontents;
 
-	// perform a pmove
-	gi.Pmove (&pm);
+	{
+		// Jump
+		// Don't let this player touch missiles, etc. when moving.
+		Jump::playertracetouch_guard_t guard(ent);
+		// Jump
+
+		// perform a pmove
+		gi.Pmove (&pm);
+	}
+
 
 	// save results of pmove
 	client->ps.pmove = pm.s;


### PR DESCRIPTION
This fixes players touching missiles (rockets, blaster shots) and grenades when the PLAYER is moving. This same problem exists in the current jump mod as well.


Should also have this change (and allow weapons to be picked up so you can test it 😄).
```
diff --git a/src/jump.cpp b/src/jump.cpp
index a35f703..6399c9f 100644
--- a/src/jump.cpp
+++ b/src/jump.cpp
@@ -255,7 +255,7 @@ namespace Jump
     {
         // Remove spectator flags
         ent->movetype = MOVETYPE_WALK;
-        ent->solid = SOLID_BBOX;
+        ent->solid = SOLID_TRIGGER;
         ent->flags = 0;
         ent->svflags = 0;
         ent->deadflag = DEAD_NO;
```