### PR TITLE
Refactor mset, make it less hardcoded

### DIFF
--- a/jumpserver/jump_cmds.cpp
+++ b/jumpserver/jump_cmds.cpp
@@ -14,6 +14,7 @@
 #include "rapidjson/document.h"
 #include "jump_local_database.h"
 #include "jump_spawn.h"
+#include "jump_msets.h"
 
 namespace Jump
 {
@@ -47,7 +48,9 @@ namespace Jump
         { "jumpers", Cmd_Jump_Jumpers },
         { "maplist", Cmd_Jump_Maplist },
         { "maplistnew", Cmd_Jump_MaplistNew },
-
+        { "mset", Cmd_Jump_MSet },
+        { "msetlist", Cmd_Jump_MSetList },
+        
         { "votetime", Cmd_Jump_Vote_Time },
         { "timevote", Cmd_Jump_Vote_Time },
         { "nominate", Cmd_Jump_Vote_Nominate },
@@ -896,7 +899,33 @@ namespace Jump
         LocalScores::PrintMaplist(ent, false);
     }
 
+    void Cmd_Jump_MSet(edict_t* ent)
+    {
+        // TODO: Check admin level.
+        if (!sv_cheats->value)
+        {
+            gi.cprintf(ent, PRINT_HIGH, "Cheats must be enabled!\n");
+            return;
+        }
 
+        std::string mset_name = gi.argv(1);
+        std::string value = gi.argv(2);
+
+        MSets::SetMSetSafe_Cmd(ent, mset_name, value);
+    }
+
+    void Cmd_Jump_MSetList(edict_t* ent)
+    {
+        // TODO: Check admin level.
+        if (!sv_cheats->value)
+        {
+            gi.cprintf(ent, PRINT_HIGH, "Cheats must be enabled!\n");
+            return;
+        }
+
+        MSets::PrintMSetList(ent);
+    }
+    
 
 
 

--- a/jumpserver/jump_cmds.h
+++ b/jumpserver/jump_cmds.h
@@ -33,6 +33,8 @@ namespace Jump
     void Cmd_Jump_Jumpers(edict_t* ent);
     void Cmd_Jump_Maplist(edict_t* ent);
     void Cmd_Jump_MaplistNew(edict_t* ent);
+    void Cmd_Jump_MSet(edict_t* ent);
+    void Cmd_Jump_MSetList(edict_t* ent);
 
     // Global database cmd responses
     void HandleGlobalCmdResponse(const global_cmd_response& response);

--- a/jumpserver/jump_msets.h
+++ b/jumpserver/jump_msets.h
@@ -26,10 +26,38 @@ public:
     static void LoadMapperMSets(const char* args);
     static void LoadServerMSets();
 
+    static void PrintMSetList(edict_t* ent);
+    static bool SetMSetSafe_Cmd(edict_t* ent, const std::string mset_name, const std::string& value);
+
 private:
+    enum MSetType_t {
+        MSETTYPE_INVALID = 0,
+
+        MSETTYPE_INTEGER,
+        MSETTYPE_REAL,
+        MSETTYPE_BOOLEAN,
+        MSETTYPE_STRING, // Not implemented.
+    };
+
+    typedef void (*MSetChangeCbPost)();
+
+    struct MSetData {
+        volatile void* value; // Pointer to the data.
+        
+        const MSetType_t type; // Variable type.
+        
+        const std::string name; // Name of the mset.
+
+        const MSetChangeCbPost change_cb_post; // Callback AFTER mset was changed.
+    };
+
+    static MSetData* GetMSetByName(const std::string& mset_name);
+    static std::string GetMSetValue(const MSetData* mset);
 
     static void ResetMSets();
     static void ApplyMSets(const std::map<std::string, std::string>& msets);
+
+    static bool SetMSetSafe(MSetData* mset, const std::string value);
 
     static bool _fastTele;
     static bool _grenadelauncher;
@@ -44,6 +72,11 @@ private:
 
     static std::map<std::string, std::string> _mapperMSets; // <mset name, value>
     static std::map<std::string, std::string> _serverMSets; // <mset name, value>
+
+    static MSetData MSets::_msets[];
+
+
+    static void GravityChanged();
 };
 
 }


### PR DESCRIPTION
Msets can now be changed more programmatically with `MSets::SetMSetSafe`.

Added **cheat protected** (till admin stuff is implemented) commands:
```
mset <mset name> <new value> - Change mset value
msetlist - Lists all msets and their values.
```