### PR TITLE
Implement idle status (#21)

### DIFF
--- a/jumpserver/g_local.h
+++ b/jumpserver/g_local.h
@@ -978,6 +978,8 @@ struct gclient_s
 
     // Jump
 	Jump::client_data_t* jumpdata;
+    // persistent data (between level changes)
+    Jump::client_pers_data_t* jumppers;
     // Jump
 };
 

--- a/jumpserver/g_save.c
+++ b/jumpserver/g_save.c
@@ -151,6 +151,10 @@ void InitGame()
 	// dm map list
 	//sv_maplist = gi.cvar ("sv_maplist", "", 0);
 
+	// Jump
+	Jump::JumpInitCvars();
+	// Jump
+
 	// items
 	InitItems();
 

--- a/jumpserver/jump.cpp
+++ b/jumpserver/jump.cpp
@@ -351,17 +351,37 @@ namespace Jump
         ent->client->jumpdata->replay_recording.clear();
     }
 
+    /// <summary>
+    // Every time a player joins the game. This does NOT get called between level changes.
+    /// </summary>
+    /// <param name="ent">Player entity</param>
     void JumpClientConnect(edict_t* ent)
     {
         ent->client->jumpdata = new client_data_t();
+
+        // Only init persistent data here.
+        ent->client->jumppers = new client_pers_data_t();
     }
 
+    /// <summary>
+    /// Every time a player leaves the game. This does NOT get called between level changes.
+    /// </summary>
+    /// <param name="ent"></param>
     void JumpClientDisconnect(edict_t* ent)
     {
         delete ent->client->jumpdata;
         ent->client->jumpdata = NULL;
 
         VoteSystem::RemoveParticipant(ent);
+
+        assert(ent->client->jumppers != nullptr);
+        delete ent->client->jumppers;
+        ent->client->jumppers = nullptr;
+    }
+
+    void JumpInitCvars()
+    {
+        jump_server.cvar_idle_time = gi.cvar("jump_idle_time", "60", 0);
     }
 
     void JumpInitGame()
@@ -673,6 +693,97 @@ namespace Jump
         ChangeWeapon(ent);
         // TODO: does this work correctly with hand grenades?
         // TODO: does this work correctly by setting newweapon to nullptr?
+    }
+
+    void UpdatePlayerIdleState(edict_t* ent, usercmd_t* ucmd)
+    {
+        auto client = ent->client;
+
+        auto prev_state = client->jumppers->idle_state;
+        auto new_state = IdleStateEnum::None;
+
+        const uint64_t max_idletime_msec = jump_server.cvar_idle_time->value * 1000;
+
+        bool moved = false;
+
+        auto moved_func = [&]()
+        {
+            // Never count spectator moving if already idle.
+            if (prev_state != IdleStateEnum::None && client->jumpdata->team == TeamEnum::Spectator)
+            {
+                return false;
+            }
+
+            return  ucmd->forwardmove != client->jumppers->prev_idle_forwardmove ||
+                    ucmd->sidemove != client->jumppers->prev_idle_sidemove ||
+                    ucmd->upmove != client->jumppers->prev_idle_upmove;
+        };
+
+        if (moved_func())
+        {
+            client->jumppers->idle_msec = 0;
+
+            moved = true;
+        }
+        else
+        {
+            client->jumppers->idle_msec += ucmd->msec;
+        }
+
+        if (!moved && client->jumppers->idle_msec >= max_idletime_msec)
+        {
+            new_state = IdleStateEnum::Auto;
+        }
+
+        if (!moved && prev_state == IdleStateEnum::Self)
+        {
+            new_state = IdleStateEnum::Self;
+        }
+        
+        if (prev_state != new_state)
+        {
+            Logger::Debug(va("Player's %s idle state changed from %i to %i.", ent->client->pers.netname, prev_state, new_state));
+
+            NotifyPlayerIdleChange(ent, prev_state, new_state);
+        }
+
+        client->jumppers->idle_state = new_state;
+        client->jumppers->prev_idle_forwardmove = ucmd->forwardmove;
+        client->jumppers->prev_idle_sidemove = ucmd->sidemove;
+        client->jumppers->prev_idle_upmove = ucmd->upmove;
+    }
+
+    void ForcePlayerIdleStateWakeup(edict_t* ent)
+    {
+        if (ent->client->jumppers->idle_state != IdleStateEnum::None)
+        {
+            Logger::Debug(va("Player's %s idle state was changed by forcing a wake up!", ent->client->pers.netname));
+
+            NotifyPlayerIdleChange(ent, ent->client->jumppers->idle_state, IdleStateEnum::None);
+        }
+
+        ent->client->jumppers->idle_msec = 0;
+        ent->client->jumppers->idle_state = IdleStateEnum::None;
+    }
+
+    void NotifyPlayerIdleChange(edict_t* ent, IdleStateEnum prev_state, IdleStateEnum new_state)
+    {
+        if (prev_state == new_state)
+            return;
+
+
+        if (new_state == IdleStateEnum::Auto)
+        {
+            gi.cprintf(ent, PRINT_HIGH, "You are now marked as idle for being inactive for too long.\n");
+        }
+        else if (new_state == IdleStateEnum::Self)
+        {
+            gi.cprintf(ent, PRINT_HIGH, "You are now marked as idle.\n");
+        }
+        else if (new_state == IdleStateEnum::None)
+        {
+            gi.cprintf(ent, PRINT_HIGH, "You are no longer marked as idle!\n");
+        }
     }
 
     void AdjustReplaySpeed(edict_t* ent, uint8_t oldKeyStates, uint8_t newKeyStates)

--- a/jumpserver/jump.cpp
+++ b/jumpserver/jump.cpp
@@ -730,7 +730,7 @@ namespace Jump
             client->jumppers->idle_msec += ucmd->msec;
         }
 
-        if (!moved && client->jumppers->idle_msec >= max_idletime_msec)
+        if (!moved && max_idletime_msec != 0 && client->jumppers->idle_msec >= max_idletime_msec)
         {
             new_state = IdleStateEnum::Auto;
         }

--- a/jumpserver/jump.h
+++ b/jumpserver/jump.h
@@ -28,6 +28,7 @@ namespace Jump
 
     void JumpClientConnect(edict_t* ent);
     void JumpClientDisconnect(edict_t* ent);
+    void JumpInitCvars();
     void JumpInitGame();
     void JumpRunFrame();
 
@@ -40,6 +41,10 @@ namespace Jump
     void InitializeClientEnt(edict_t* ent);
 
     void RemoveAllPlayerWeapons(edict_t* ent);
+
+    void UpdatePlayerIdleState(edict_t* ent, usercmd_t* ucmd);
+    void ForcePlayerIdleStateWakeup(edict_t* ent);
+    void NotifyPlayerIdleChange(edict_t* ent, IdleStateEnum prev_state, IdleStateEnum new_state);
 
     void AdjustReplaySpeed(edict_t* ent, uint8_t oldKeyStates, uint8_t newKeyStates);
     const char* GetReplaySpeedString(ReplaySpeed speed);

--- a/jumpserver/jump_cmds.cpp
+++ b/jumpserver/jump_cmds.cpp
@@ -51,6 +51,7 @@ namespace Jump
         { "mset", Cmd_Jump_MSet },
         { "msetlist", Cmd_Jump_MSetList },
         { "team", Cmd_Jump_Team },
+        { "idle", Cmd_Jump_Idle },
         
         { "votetime", Cmd_Jump_Vote_Time },
         { "timevote", Cmd_Jump_Vote_Time },
@@ -949,6 +950,23 @@ namespace Jump
         }
     }
 
+    void Cmd_Jump_Idle(edict_t* ent)
+    {
+        auto prev_state = ent->client->jumppers->idle_state;
+
+        ent->client->jumppers->idle_msec = 0;
+
+        if (prev_state != IdleStateEnum::None)
+        {
+            ent->client->jumppers->idle_state = IdleStateEnum::None;
+        }
+        else
+        {
+            ent->client->jumppers->idle_state = IdleStateEnum::Self;
+        }
+
+        NotifyPlayerIdleChange(ent, prev_state, ent->client->jumppers->idle_state);
+    }
 
 
     void HandleGlobalCmdResponse(const global_cmd_response& response)

--- a/jumpserver/jump_cmds.h
+++ b/jumpserver/jump_cmds.h
@@ -36,6 +36,7 @@ namespace Jump
     void Cmd_Jump_MSet(edict_t* ent);
     void Cmd_Jump_MSetList(edict_t* ent);
     void Cmd_Jump_Team(edict_t* ent);
+    void Cmd_Jump_Idle(edict_t* ent);
 
     // Global database cmd responses
     void HandleGlobalCmdResponse(const global_cmd_response& response);

--- a/jumpserver/jump_menu.cpp
+++ b/jumpserver/jump_menu.cpp
@@ -105,6 +105,8 @@ namespace Jump
 
 		const int num_maps = jump_server.maplist.size();
 
+		const std::string idle_postfix = " (idle)";
+
 		std::vector<edict_t*> clients_hard;
 		std::vector<edict_t*> clients_easy;
 		std::vector<edict_t*> clients_spec;
@@ -151,6 +153,7 @@ namespace Jump
 
 			float best_time_msec = player->client->jumpdata->cached_time_msec;
 			int num_completions = player->client->jumpdata->cached_completions;
+			auto idle_state = player->client->jumppers->idle_state;
 
 
 			std::string ping = std::to_string(player->client->ping);
@@ -159,6 +162,7 @@ namespace Jump
 			std::string completions = num_completions > 0 ? std::to_string(num_completions) : "----";
 			std::string num_maps_completed = std::to_string(player->client->jumpdata->cached_maps_completed);
 			std::string completions_percentage = to_string_with_precision(completion_frac * 100, 1);
+			std::string team = idle_state != IdleStateEnum::None ? "Idle" : "Hard";
 			if (player == ent)
 			{
 				ping = GetGreenConsoleText(ping);
@@ -173,7 +177,7 @@ namespace Jump
 			ss << std::right << std::setw(4) << completions << " ";
 			ss << std::right << std::setw(4) << num_maps_completed << "  ";
 			ss << std::right << std::setw(4) << completions_percentage << "  ";
-			ss << "Hard" << "\" ";
+			ss << team << "\" ";
 		}
 
 		// If there are no hard players, shift team easy players to the top, else add padding between the groups.
@@ -201,7 +205,7 @@ namespace Jump
 
 			float best_time_msec = player->client->jumpdata->cached_time_msec;
 			int num_completions = player->client->jumpdata->cached_completions;
-
+			auto idle_state = player->client->jumppers->idle_state;
 
 			std::string ping = std::to_string(player->client->ping);
 			std::string username = player->client->pers.netname;
@@ -209,6 +213,7 @@ namespace Jump
 			std::string completions = num_completions > 0 ? std::to_string(num_completions) : "----";
 			std::string num_maps_completed = std::to_string(player->client->jumpdata->cached_maps_completed);
 			std::string completions_percentage = to_string_with_precision(completion_frac * 100, 1);
+			std::string team = idle_state != IdleStateEnum::None ? "Idle" : "Easy";
 			if (player == ent)
 			{
 				ping = GetGreenConsoleText(ping);
@@ -223,7 +228,7 @@ namespace Jump
 			ss << std::right << std::setw(4) << completions << " ";
 			ss << std::right << std::setw(4) << num_maps_completed << "  ";
 			ss << std::right << std::setw(4) << completions_percentage << "  ";
-			ss << "Easy" << "\" ";
+			ss << team << "\" ";
 		}
 
 		if (players_added == 0)
@@ -254,6 +259,8 @@ namespace Jump
 			}
 			edict_t* player = clients_spec[i];
 
+			auto idle_state = player->client->jumppers->idle_state;
+
 			std::string ping = std::to_string(player->client->ping);
 			std::string username = player->client->pers.netname;
 			if (player == ent)
@@ -262,10 +269,15 @@ namespace Jump
 				username = GetGreenConsoleText(username);
 			}
 
+			if (idle_state != IdleStateEnum::None)
+			{
+				username += idle_postfix;
+			}
+
 			int yv = yv_offset + (i * 8);
 			ss << "yv " << yv << " string \"";
 			ss << std::right << std::setw(4) << ping << " ";
-			ss << std::left << std::setw(15) << username << " ";
+			ss << std::left << std::setw(22) << username << " "; // offset: 15 + 7 = 22
 			// TODO: idle, who you are speccing, what replay you are watching
 			ss << "\" ";
 		}

--- a/jumpserver/jump_spawn.cpp
+++ b/jumpserver/jump_spawn.cpp
@@ -22,6 +22,8 @@ void Spawn::JoinTeamEasy(edict_t* ent)
 
     InitDefaultSpawnVariables(ent);
 
+    ForcePlayerIdleStateWakeup(ent);
+
     if (ent->client->jumpdata->stores.HasStore())
     {
         store_data_t data = ent->client->jumpdata->stores.GetStore(1);
@@ -48,6 +50,8 @@ void Spawn::JoinTeamHard(edict_t* ent)
     AssignTeamSkin(ent);
 
     InitDefaultSpawnVariables(ent);
+
+    ForcePlayerIdleStateWakeup(ent);
 
     edict_t* spawn = SelectPlayerSpawn();
     MovePlayerToSpawn(ent, spawn, true);

--- a/jumpserver/jump_types.h
+++ b/jumpserver/jump_types.h
@@ -311,7 +311,7 @@ namespace Jump
         // MapId in the local database for the current level
         int local_map_id;
 
-        // How long the player needs to be idle for, in seconds, before they are set as idle.
+        // How long the player needs to be idle for, in seconds, before they are set as idle. 0 = no auto-idling
         cvar_t* cvar_idle_time;
     };
 

--- a/jumpserver/jump_types.h
+++ b/jumpserver/jump_types.h
@@ -86,6 +86,13 @@ namespace Jump
         Zero = 2,
     };
 
+    enum class IdleStateEnum : int
+    {
+        None = 0, // Player not idle.
+        Auto, // Player was idle for too long.
+        Self // Player used 'idle' command and set themselves idle.
+    };
+
     // How much disk space is required to store a replay:
     // 48 bytes per replay frame, 10 frames per second (because server runs at 10 frames/s) = 480 bytes/s
     // 15 seconds = 7.2 kB
@@ -171,6 +178,26 @@ namespace Jump
         int map_count;
     };
 
+    // Data unique to each client that is persists between level changes.
+    class client_pers_data_t
+    {
+    public:
+        client_pers_data_t()
+        {
+            prev_idle_upmove = 0;
+            prev_idle_forwardmove = 0;
+            prev_idle_sidemove = 0;
+            idle_state = IdleStateEnum::None;
+            idle_msec = 0;
+        }
+
+        int prev_idle_upmove;
+        int prev_idle_forwardmove;
+        int prev_idle_sidemove;
+        IdleStateEnum idle_state;
+        uint64_t idle_msec;
+    };
+
     // Data unique to each client
     class client_data_t
     {
@@ -236,6 +263,8 @@ namespace Jump
             time_added_mins = 0;
             replay_now_time_ms = INT64_MAX;
             local_map_id = -1;
+
+            cvar_idle_time = nullptr;
         }
 
         LevelStateEnum level_state;    // freeplay, voting, or intermission
@@ -281,6 +310,9 @@ namespace Jump
 
         // MapId in the local database for the current level
         int local_map_id;
+
+        // How long the player needs to be idle for, in seconds, before they are set as idle.
+        cvar_t* cvar_idle_time;
     };
 
     // Converts a replay buffer into a byte array

--- a/jumpserver/jump_voting.cpp
+++ b/jumpserver/jump_voting.cpp
@@ -304,10 +304,12 @@ namespace Jump
                 continue;
             }
 
-            if (!cur_vote_type->CanParticipate(player))
+            // Idlers can't participate!
+            if (client->jumppers->idle_state != IdleStateEnum::None)
                 continue;
 
-            // TODO: Check idle
+            if (!cur_vote_type->CanParticipate(player))
+                continue;
 
 
             int player_num = player - g_edicts;
@@ -510,6 +512,11 @@ namespace Jump
             return false;
         }
 
+        if (player->client->jumppers->idle_state != IdleStateEnum::None)
+        {
+            gi.cprintf(player, PRINT_HIGH, "You cannot start a vote while being idle!\n");
+            return false;
+        }
 
         auto vote = GetVoteType(vote_type);
         if (!vote)

--- a/jumpserver/p_client.c
+++ b/jumpserver/p_client.c
@@ -1029,6 +1029,8 @@ void ClientThink (edict_t *ent, usercmd_t *ucmd)
 
 	Jump::AdjustReplaySpeed(ent, old_key_states, ent->client->jumpdata->key_states);
 
+	Jump::UpdatePlayerIdleState(ent, ucmd);
+
 	// Apply a health regen rate of 10/frame (equal to 100/s)
 	if (ent->health > 0)
 	{


### PR DESCRIPTION
- Added persistent data class (between level changes)
- Auto-idling should work the same way as before.
- Cannot vote or start one.
- Configurable through `jump_idle_time`-cvar