### PR TITLE
Local admin system (#27)

### DIFF
--- a/jumpserver/jump_admin.cpp
+++ b/jumpserver/jump_admin.cpp
@@ -1,0 +1,108 @@
+#include "jump_admin.h"
+#include "jump_local_database.h"
+#include "jump_logger.h"
+
+
+namespace Jump
+{
+void AdminSystem::Init()
+{
+
+}
+
+void AdminSystem::PlayerConnected(edict_t* player)
+{
+    player->client->jumppers->admin.authenticated = false;
+    player->client->jumppers->admin.admin_flags = AdminFlagEnum::ADMIN_FLAG_NONE;
+}
+
+void AdminSystem::PlayerDisconnected(edict_t* player)
+{
+    player->client->jumppers->admin.authenticated = false;
+    player->client->jumppers->admin.admin_flags = AdminFlagEnum::ADMIN_FLAG_NONE;
+}
+
+void AdminSystem::Login(edict_t* player, const std::string& password)
+{
+    const std::string username = player->client->pers.netname;
+
+    AdminFlagEnum flags = AdminFlagEnum::ADMIN_FLAG_NONE;
+    auto authenticated = LocalDatabase::AdminAuthenticate(username, password, &flags);
+
+    if (authenticated)
+    {
+        Logger::Activity(va("Player %s logged in as admin (flags: %i)", username.c_str(), static_cast<int>(flags)));
+    }
+    else
+    {
+        Logger::Activity(va("Player %s attempted to log in as admin!", username.c_str()));
+    }
+    
+
+    player->client->jumppers->admin.authenticated = authenticated;
+    player->client->jumppers->admin.admin_flags = flags;
+
+    if (authenticated)
+    {
+        gi.bprintf(PRINT_HIGH, "%s is now logged in as an admin!\n", username.c_str());
+    }
+}
+
+void AdminSystem::Logout(edict_t* player)
+{
+    const std::string username = player->client->pers.netname;
+
+    if (!player->client->jumppers->admin.authenticated)
+    {
+        Logger::Activity(va("Player %s attempted to log out as admin!", username.c_str()));
+        return;
+    }
+
+    auto prev_levels = player->client->jumppers->admin.admin_flags;
+
+    player->client->jumppers->admin.authenticated = false;
+    player->client->jumppers->admin.admin_flags = AdminFlagEnum::ADMIN_FLAG_NONE;
+
+    gi.bprintf(PRINT_HIGH, "%s is no longer logged in as an admin!\n", username.c_str());
+
+    Logger::Activity(va("Player %s logged out as admin (flags: %i)!", username.c_str(), prev_levels));
+}
+
+void AdminSystem::AddAdmin(edict_t* player, const std::string& username, const std::string& password)
+{
+    if (!CanPerformAction(player, AdminFlagEnum::ADMIN_FLAG_ADMINS))
+    {
+        gi.cprintf(player, PRINT_HIGH, "You cannot perform this command!\n");
+        return;
+    }
+
+    LocalDatabase::AddAdmin(username, password);
+}
+
+void AdminSystem::RemoveAdmin(edict_t* player, const std::string& username)
+{
+    if (!CanPerformAction(player, AdminFlagEnum::ADMIN_FLAG_ADMINS))
+    {
+        gi.cprintf(player, PRINT_HIGH, "You cannot perform this command!\n");
+        return;
+    }
+
+    LocalDatabase::RemoveAdmin(username);
+}
+
+bool AdminSystem::CanPerformAction(edict_t* player, AdminFlagEnum required_flags)
+{
+    if (!player->client->jumppers->admin.authenticated)
+    {
+        return false;
+    }
+
+    return CanPerformAction(required_flags, player->client->jumppers->admin.admin_flags);
+}
+
+bool AdminSystem::CanPerformAction(AdminFlagEnum required_flags, AdminFlagEnum comp_flags)
+{
+    return ((int)required_flags & (int)comp_flags) == (int)required_flags;
+}
+
+}

--- a/jumpserver/jump_admin.h
+++ b/jumpserver/jump_admin.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "g_local.h"
+
+namespace Jump
+{
+    class AdminSystem
+    {
+    public:
+        static void Init();
+
+        static void PlayerConnected(edict_t* player);
+        static void PlayerDisconnected(edict_t* player);
+
+        static void Login(edict_t* player, const std::string& password);
+        static void Logout(edict_t* player);
+
+        static void AddAdmin(edict_t* player, const std::string& username, const std::string& password);
+        static void RemoveAdmin(edict_t* player, const std::string& username);
+
+        static bool CanPerformAction(edict_t* player, AdminFlagEnum required_flags);
+        static bool CanPerformAction(AdminFlagEnum required_flags, AdminFlagEnum comp_flags);
+
+    private:
+
+    };
+}

--- a/jumpserver/jump_cmds.cpp
+++ b/jumpserver/jump_cmds.cpp
@@ -15,6 +15,7 @@
 #include "jump_local_database.h"
 #include "jump_spawn.h"
 #include "jump_msets.h"
+#include "jump_admin.h"
 
 namespace Jump
 {
@@ -52,6 +53,8 @@ namespace Jump
         { "msetlist", Cmd_Jump_MSetList },
         { "team", Cmd_Jump_Team },
         { "idle", Cmd_Jump_Idle },
+        { "adminlogin", Cmd_Jump_AdminLogin },
+        { "adminlogout", Cmd_Jump_AdminLogout },
         
         { "votetime", Cmd_Jump_Vote_Time },
         { "timevote", Cmd_Jump_Vote_Time },
@@ -966,6 +969,16 @@ namespace Jump
         }
 
         NotifyPlayerIdleChange(ent, prev_state, ent->client->jumppers->idle_state);
+    }
+
+    void Cmd_Jump_AdminLogin(edict_t* ent)
+    {
+        AdminSystem::Login(ent, gi.argv(1));
+    }
+
+    void Cmd_Jump_AdminLogout(edict_t* ent)
+    {
+        AdminSystem::Logout(ent);
     }
 
 

--- a/jumpserver/jump_cmds.h
+++ b/jumpserver/jump_cmds.h
@@ -37,6 +37,8 @@ namespace Jump
     void Cmd_Jump_MSetList(edict_t* ent);
     void Cmd_Jump_Team(edict_t* ent);
     void Cmd_Jump_Idle(edict_t* ent);
+    void Cmd_Jump_AdminLogin(edict_t* ent);
+    void Cmd_Jump_AdminLogout(edict_t* ent);
 
     // Global database cmd responses
     void HandleGlobalCmdResponse(const global_cmd_response& response);

--- a/jumpserver/jump_local_database.h
+++ b/jumpserver/jump_local_database.h
@@ -62,6 +62,12 @@ public:
     static int GetMapId(const std::string& mapname);
     static std::string GetUserName(int userId);
     static void GetTotalCompletions(const std::string& mapname, int& totalPlayers, int& totalCompletions);
+    
+    static bool AdminAuthenticate(const std::string& username, const std::string& password, AdminFlagEnum* flags = nullptr);
+    static bool AddAdmin(const std::string& username, const std::string& password);
+    static bool RemoveAdmin(const std::string& username);
+    static bool AddAdminFlags(const std::string& username, AdminFlagEnum flags);
+    static bool RemoveAdminFlags(const std::string& username, AdminFlagEnum flags);
 
     static void MigrateAll();
 
@@ -70,6 +76,7 @@ private:
     static void CreateTableMaps();
     static void CreateTableUsers();
     static void CreateTableMapTimes();
+    static void CreateTableAdmins();
 
     // Misc helpers
     static bool GetReplay(int mapId, int userId, std::vector<replay_frame_t>& replay, int& timeMs);
@@ -82,8 +89,11 @@ private:
     static void MigrateReplays(const std::string& folder);
     static bool MigrateReplay(const std::string& mapname, int userid, const std::vector<replay_frame_t>& replay);
     static bool ConvertOldReplay(const std::string& demoFile, std::vector<replay_frame_t>& newReplay);
+
+    static std::string SaltString(const std::string& str);
     
     static sqlite3* _db;
+    static std::string _adminPasswordSalt;
 };
 
 }

--- a/jumpserver/jump_types.h
+++ b/jumpserver/jump_types.h
@@ -93,6 +93,29 @@ namespace Jump
         Self // Player used 'idle' command and set themselves idle.
     };
 
+    enum class AdminFlagEnum : int
+    {
+        ADMIN_FLAG_NONE             = 0,
+        ADMIN_FLAG_GENERIC          = (1 << 0),
+        ADMIN_FLAG_KICK             = (1 << 1),
+        ADMIN_FLAG_BAN              = (1 << 2),
+        ADMIN_FLAG_PERMABAN         = (1 << 3),
+        ADMIN_FLAG_MAPCHANGE        = (1 << 4),
+
+        ADMIN_FLAG_VOTE_KICK        = (1 << 5),
+        ADMIN_FLAG_VOTE_BAN         = (1 << 6),
+        ADMIN_FLAG_VOTE_MAPCHANGE   = (1 << 7),
+
+        ADMIN_FLAG_ADMINS           = (1 << 8), // Add or remove admins and admin flags
+    };
+
+    typedef struct
+    {
+        bool authenticated;
+
+        AdminFlagEnum admin_flags;
+    } admin_data_t;
+
     // How much disk space is required to store a replay:
     // 48 bytes per replay frame, 10 frames per second (because server runs at 10 frames/s) = 480 bytes/s
     // 15 seconds = 7.2 kB
@@ -189,6 +212,8 @@ namespace Jump
             prev_idle_sidemove = 0;
             idle_state = IdleStateEnum::None;
             idle_msec = 0;
+            admin.authenticated = false;
+            admin.admin_flags = AdminFlagEnum::ADMIN_FLAG_NONE;
         }
 
         int prev_idle_upmove;
@@ -196,6 +221,7 @@ namespace Jump
         int prev_idle_sidemove;
         IdleStateEnum idle_state;
         uint64_t idle_msec;
+        admin_data_t admin;
     };
 
     // Data unique to each client

--- a/jumpserver/jump_utils.cpp
+++ b/jumpserver/jump_utils.cpp
@@ -6,6 +6,21 @@
 #include <time.h>
 #include <sstream>
 
+#ifdef WIN32
+#include <Windows.h>
+#endif
+
+static void GetLaunchParams(const char*** argv, int& argc)
+{
+#ifdef WIN32
+    *argv = (const char**)__argv;
+    argc = __argc;
+#else
+    *argv = nullptr;
+    args = 0;
+#endif
+}
+
 namespace Jump
 {
     // Returns the path to the mod files relative to the root q2 folder ("jumprefresh")
@@ -377,6 +392,43 @@ namespace Jump
         char buffer[16] = {};
         strftime(buffer, sizeof(buffer), "%d/%m/%y", &tm);
         return buffer;
+    }
+
+    bool LaunchParameterExists(const std::string& param)
+    {
+        auto argc = gi.argc();
+        for (int i = 0; i < argc; i++)
+        {
+            if (StringCompareInsensitive(gi.argv(i), param))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    const char* GetLaunchParameterValue(const std::string& param)
+    {
+        int argc = 0;
+        const char** argv = nullptr;
+        GetLaunchParams(&argv, argc);
+        if (argv == nullptr || !argc)
+        {
+            return nullptr;
+        }
+
+        for (int i = 0; i < argc; i++)
+        {
+            if (StringCompareInsensitive(argv[i], param))
+            {
+                auto value_index = i + 1;
+                if (value_index < argc)
+                    return argv[value_index];
+            }
+        }
+
+        return nullptr;
     }
 
 } // namespace Jump

--- a/jumpserver/jump_utils.h
+++ b/jumpserver/jump_utils.h
@@ -153,4 +153,7 @@ namespace Jump
         out << std::fixed << value;
         return out.str();
     }
+
+    bool LaunchParameterExists(const std::string& param);
+    const char* GetLaunchParameterValue(const std::string& param);
 }

--- a/jumpserver/jumpserver.vcxproj
+++ b/jumpserver/jumpserver.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -90,6 +90,7 @@
       <CompileAs>CompileAsCpp</CompileAs>
       <DisableSpecificWarnings>4996</DisableSpecificWarnings>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <ConformanceMode>Default</ConformanceMode>
     </ClCompile>
     <Link>
       <TargetMachine>MachineX86</TargetMachine>
@@ -100,8 +101,8 @@
       <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;Winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
-      <Command>copy /B /Y "$(OutDir)$(TargetFileName)" "G:\Quake2Dev\jumprefresh";
-copy /B /Y "$(OutDir)$(TargetName).pdb" "G:\Quake2Dev\jumprefresh";</Command>
+      <Command>copy /B /Y "$(OutDir)$(TargetFileName)" "D:\_q2\jumprefresh";
+copy /B /Y "$(OutDir)$(TargetName).pdb" "D:\_q2\jumprefresh";</Command>
       <Message>Copying binaries to q2 jumprefresh folder</Message>
     </PostBuildEvent>
   </ItemDefinitionGroup>
@@ -114,6 +115,7 @@ copy /B /Y "$(OutDir)$(TargetName).pdb" "G:\Quake2Dev\jumprefresh";</Command>
       <CompileAs>CompileAsCpp</CompileAs>
       <DisableSpecificWarnings>4996</DisableSpecificWarnings>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <ConformanceMode>Default</ConformanceMode>
     </ClCompile>
     <Link>
       <TargetMachine>MachineX86</TargetMachine>
@@ -127,8 +129,8 @@ copy /B /Y "$(OutDir)$(TargetName).pdb" "G:\Quake2Dev\jumprefresh";</Command>
     </Link>
     <PostBuildEvent />
     <PostBuildEvent>
-      <Command>copy /B /Y "$(OutDir)$(TargetFileName)" "G:\Quake2Dev\jumprefresh";
-copy /B /Y "$(OutDir)$(TargetName).pdb" "G:\Quake2Dev\jumprefresh";</Command>
+      <Command>copy /B /Y "$(OutDir)$(TargetFileName)" "D:\_q2\jumprefresh";
+copy /B /Y "$(OutDir)$(TargetName).pdb" "D:\_q2\jumprefresh";</Command>
       <Message>Copying binaries to q2 jumprefresh folder</Message>
     </PostBuildEvent>
   </ItemDefinitionGroup>
@@ -137,6 +139,7 @@ copy /B /Y "$(OutDir)$(TargetName).pdb" "G:\Quake2Dev\jumprefresh";</Command>
       <CompileAs>CompileAsCpp</CompileAs>
       <DisableSpecificWarnings>4996</DisableSpecificWarnings>
       <WarningLevel>EnableAllWarnings</WarningLevel>
+      <ConformanceMode>Default</ConformanceMode>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -144,6 +147,7 @@ copy /B /Y "$(OutDir)$(TargetName).pdb" "G:\Quake2Dev\jumprefresh";</Command>
       <CompileAs>CompileAsCpp</CompileAs>
       <DisableSpecificWarnings>4996</DisableSpecificWarnings>
       <WarningLevel>Level3</WarningLevel>
+      <ConformanceMode>Default</ConformanceMode>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -165,6 +169,7 @@ copy /B /Y "$(OutDir)$(TargetName).pdb" "G:\Quake2Dev\jumprefresh";</Command>
     <ClCompile Include="g_utils.c" />
     <ClCompile Include="g_weapon.c" />
     <ClCompile Include="jump.cpp" />
+    <ClCompile Include="jump_admin.cpp" />
     <ClCompile Include="jump_cmds.cpp" />
     <ClCompile Include="jump_ents.cpp" />
     <ClCompile Include="jump_ghost.cpp" />
@@ -205,12 +210,14 @@ copy /B /Y "$(OutDir)$(TargetName).pdb" "G:\Quake2Dev\jumprefresh";</Command>
   <ItemGroup>
     <ClInclude Include="base64.h" />
     <ClInclude Include="g_chase.h" />
+    <ClInclude Include="jump_admin.h" />
     <ClInclude Include="jump_ents.h" />
     <ClInclude Include="jump_ghost.h" />
     <ClInclude Include="jump_local_database.h" />
     <ClInclude Include="jump_msets.h" />
     <ClInclude Include="jump_spawn.h" />
     <ClInclude Include="sqlite3.h" />
+    <ClInclude Include="thirdparty\picosha3\picosha3.h" />
     <ClInclude Include="thread_queue.h" />
     <ClInclude Include="game.h" />
     <ClInclude Include="g_local.h" />

--- a/jumpserver/jumpserver.vcxproj.filters
+++ b/jumpserver/jumpserver.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
@@ -147,6 +147,9 @@
     <ClCompile Include="jump_msets.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="jump_admin.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="game.h">
@@ -219,6 +222,12 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="jump_msets.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="jump_admin.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="thirdparty\picosha3\picosha3.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/jumpserver/thirdparty/picosha3/LICENSE
+++ b/jumpserver/thirdparty/picosha3/LICENSE
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/jumpserver/thirdparty/picosha3/README.md
+++ b/jumpserver/thirdparty/picosha3/README.md
@@ -1,0 +1,56 @@
+# PicoSHA3
+
+PicoSHA3 is a C++14 header-only library for SHA3.
+
+* The implementation is based on [FIPS202](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf).
+* Inspired by [PicoSHA2 - a C++ SHA256 hash generator](https://github.com/okdshin/picosha2).
+
+## Generating hash and hash hex string
+
+```c++
+std::array<uint8_t, picosha3::bits_to_bytes(224)> hash{};
+auto sha3_224 = picosha3::get_sha3_generator<224>();
+std::string target = "Hello, World"; // Any STL sequence container.
+sha3_224(target.cbegin(), target.cend(), hash.begin(), hash.end());
+std::string hash_hex_string = picosha3::bytes_to_hex_string(hash);
+```
+
+## Generating hash and hash hex string from byte stream
+
+```c++
+std::array<uint8_t, picosha3::bits_to_bytes(256)> hash{};
+auto sha3_256 = picosha3::get_sha3_generator<256>();
+...
+sha3_256.process(block.cbegin(), block.cend());
+...
+sha3_256.finish();
+sha3_256.get_hash_bytes(hash.begin(), hash.end());
+std::string hash_hex_string = picosha3::bytes_to_hex_string(hash);
+```
+
+## Generating hash from a binary file
+
+```c++
+std::vector<uint8_t> s(picosha3::bits_to_bytes(384));
+auto sha3_384 = picosha3::get_sha3_generator<384>();
+std::ifstream ifs{"text.txt"};
+sha3_384(ifs, s.begin(), s.end());
+```
+
+## Generating hash hex string from std::string
+
+```c++
+std::string target = "The quick brown fox jumps over the lazy dog";
+auto sha3_512 = get_sha3_generator<512>();
+std::string hash_hex_string = sha3_512.get_hex_string(target);
+std::cout<< hash_hex_string << std::endl;
+// This output is  "01dedd5de4ef14642445ba5f5b97c15e47b9ad931326e4b0727cd94cefc44fff23f07bf543139939b49128caf436dc1bdee54fcb24023a08d9403f9b4bf0d450"
+```
+
+## Generating hex string from byte sequence
+
+```c++
+std::vector<uint8_t> src_vec(...);
+auto shake128_512 = get_shake_generator<128, 512>();
+st::string hash_hex_string = shake128_512.get_hex_string(src_vec);
+```

--- a/jumpserver/thirdparty/picosha3/picosha3.h
+++ b/jumpserver/thirdparty/picosha3/picosha3.h
@@ -1,0 +1,361 @@
+#ifndef PICOSHA3_H
+#define PICOSHA3_H
+
+#include <array>
+#include <cassert>
+#include <fstream>
+#include <iomanip>
+#include <sstream>
+
+namespace picosha3 {
+    constexpr size_t bits_to_bytes(size_t bits) { return bits / 8; };
+    constexpr static size_t b_bytes = bits_to_bytes(1600);
+    constexpr static uint64_t RC[24] = {
+      0x0000000000000001ull, 0x0000000000008082ull, 0x800000000000808Aull,
+      0x8000000080008000ull, 0x000000000000808Bull, 0x0000000080000001ull,
+      0x8000000080008081ull, 0x8000000000008009ull, 0x000000000000008Aull,
+      0x0000000000000088ull, 0x0000000080008009ull, 0x000000008000000Aull,
+      0x000000008000808Bull, 0x800000000000008Bull, 0x8000000000008089ull,
+      0x8000000000008003ull, 0x8000000000008002ull, 0x8000000000000080ull,
+      0x000000000000800Aull, 0x800000008000000Aull, 0x8000000080008081ull,
+      0x8000000000008080ull, 0x0000000080000001ull, 0x8000000080008008ull};
+
+    using byte_t = uint8_t;
+    using state_t = std::array<std::array<uint64_t, 5>, 5>;
+
+    inline void theta(state_t& A) {
+        uint64_t C[5] = {0, 0, 0, 0, 0};
+        for(size_t x = 0; x < 5; ++x) {
+            C[x] = A[x][0] ^ A[x][1] ^ A[x][2] ^ A[x][3] ^ A[x][4];
+        };
+        uint64_t D[5] = {0, 0, 0, 0, 0};
+        D[0] = C[4] ^ (C[1] << 1 | C[1] >> (64 - 1));
+        D[1] = C[0] ^ (C[2] << 1 | C[2] >> (64 - 1));
+        D[2] = C[1] ^ (C[3] << 1 | C[3] >> (64 - 1));
+        D[3] = C[2] ^ (C[4] << 1 | C[4] >> (64 - 1));
+        D[4] = C[3] ^ (C[0] << 1 | C[0] >> (64 - 1));
+        for(size_t x = 0; x < 5; ++x) {
+            for(size_t y = 0; y < 5; ++y) {
+                A[x][y] ^= D[x];
+            }
+        }
+    };
+
+    inline void rho(state_t& A) {
+        size_t x{1};
+        size_t y{0};
+        for(size_t t = 0; t < 24; ++t) {
+            size_t offset = ((t + 1) * (t + 2) / 2) % 64;
+            A[x][y] = (A[x][y] << offset) | (A[x][y] >> (64 - offset));
+            size_t tmp{y};
+            y = (2 * x + 3 * y) % 5;
+            x = tmp;
+        };
+    };
+
+    inline void pi(state_t& A) {
+        state_t tmp{A};
+        for(size_t x = 0; x < 5; ++x) {
+            for(size_t y = 0; y < 5; ++y) {
+                A[x][y] = tmp[(x + 3 * y) % 5][x];
+            }
+        }
+    };
+
+    inline void chi(state_t& A) {
+        state_t tmp{A};
+        for(size_t x = 0; x < 5; ++x) {
+            for(size_t y = 0; y < 5; ++y) {
+                A[x][y] =
+                  tmp[x][y] ^ (~(tmp[(x + 1) % 5][y]) & tmp[(x + 2) % 5][y]);
+            }
+        }
+    };
+
+    inline void iota(state_t& A, size_t round_index) {
+        A[0][0] ^= RC[round_index];
+    };
+
+    inline void keccak_p(state_t& A) {
+        for(size_t round_index = 0; round_index < 24; ++round_index) {
+            theta(A);
+            rho(A);
+            pi(A);
+            chi(A);
+            iota(A, round_index);
+        }
+    };
+
+    namespace {
+        inline void next(size_t& x, size_t& y, size_t& i) {
+            if(++i != 8) {
+                return;
+            }
+            i = 0;
+            if(++x != 5) {
+                return;
+            }
+            x = 0;
+            if(++y != 5) {
+                return;
+            }
+        }
+    } // namespace
+
+    template <typename InIter>
+    void absorb(InIter first, InIter last, state_t& A) {
+        size_t x = 0;
+        size_t y = 0;
+        size_t i = 0;
+        for(; first != last && y < 5; ++first) {
+            auto tmp = static_cast<uint64_t>(*first);
+            A[x][y] ^= (tmp << (i * 8));
+            next(x, y, i);
+        };
+    }
+
+    template <typename InContainer>
+    void absorb(const InContainer& src, state_t& A) {
+        absorb(src.cbegin(), src.cend(), A);
+    };
+
+    template <typename OutIter>
+    OutIter squeeze(const state_t& A, OutIter first, OutIter last,
+                    size_t rate_bytes) {
+        size_t x = 0;
+        size_t y = 0;
+        size_t i = 0;
+        for(size_t read_bytes = 0;
+            first != last && y < 5 && read_bytes < rate_bytes;
+            ++read_bytes, ++first) {
+            auto tmp = static_cast<uint64_t>(A[x][y]);
+            auto p = reinterpret_cast<byte_t*>(&tmp);
+            *first = *(p + i);
+            next(x, y, i);
+        }
+        return first;
+    };
+
+    template <typename OutContainer>
+    typename OutContainer::iterator
+    squeeze(const state_t& A, OutContainer& dest, size_t rate_bytes) {
+        return squeeze(A, dest.begin(), dest.end(), rate_bytes);
+    }
+
+    enum class PaddingType {
+        SHA,
+        SHAKE,
+    };
+
+    template <typename InIter>
+    std::string bytes_to_hex_string(InIter first, InIter last) {
+        std::stringstream ss;
+        ss << std::hex;
+        for(; first != last; ++first) {
+            ss << std::setw(2) << std::setfill('0')
+               << static_cast<uint64_t>(*first);
+        }
+        return ss.str();
+    }
+
+    template <typename InContainer>
+    std::string bytes_to_hex_string(const InContainer& src) {
+        return bytes_to_hex_string(src.cbegin(), src.cend());
+    }
+
+    template <size_t rate_bytes, size_t d_bytes, PaddingType padding_type>
+    class HashGenerator {
+    public:
+        HashGenerator()
+          : buffer_{}, buffer_pos_{buffer_.begin()}, A_{}, hash_{},
+            is_finished_{false} {}
+
+        void clear() {
+            clear_state();
+            clear_buffer();
+            is_finished_ = false;
+        }
+
+        template <typename InIter>
+        void process(InIter first, InIter last) {
+            static_assert(
+              sizeof(typename std::iterator_traits<InIter>::value_type) == 1,
+              "The size of input iterator value_type must be one byte.");
+
+            for(; first != last; ++first) {
+                *buffer_pos_ = *first;
+                if(++buffer_pos_ == buffer_.end()) {
+                    absorb(buffer_, A_);
+                    keccak_p(A_);
+                    clear_buffer();
+                }
+            }
+        };
+
+        void finish() {
+            add_padding();
+            absorb(buffer_, A_);
+            keccak_p(A_);
+            squeeze_();
+            is_finished_ = true;
+        };
+
+        template <typename OutIter>
+        void get_hash_bytes(OutIter first, OutIter last) {
+            if(!is_finished_) {
+                throw std::runtime_error("Not finished!");
+            }
+            std::copy(hash_.cbegin(), hash_.cend(), first);
+        };
+
+        template <typename OutCotainer>
+        void get_hash_bytes(OutCotainer& dest) {
+            get_hash_bytes(dest.begin(), dest.end());
+        };
+
+        template <typename InIter, typename OutIter>
+        void operator()(InIter in_first, InIter in_last, OutIter out_first,
+                        OutIter out_last) {
+            static_assert(
+              sizeof(typename std::iterator_traits<InIter>::value_type) == 1,
+              "The size of input iterator value_type must be one byte.");
+            static_assert(
+              sizeof(typename std::iterator_traits<OutIter>::value_type) == 1,
+              "The size of output iterator value_type must be one byte.");
+            process(in_first, in_last);
+            finish();
+            std::copy(hash_.cbegin(), hash_.cend(), out_first);
+            clear();
+        };
+
+        template <typename InIter, typename OutCotainer>
+        void operator()(InIter in_first, InIter in_last, OutCotainer& dest) {
+            operator()(in_first, in_last, dest.begin(), dest.end());
+        };
+
+        template <typename InContainer, typename OutIter>
+        void operator()(const InContainer& src, OutIter out_first,
+                        OutIter out_last) {
+            operator()(src.cbegin(), src.cend(), out_first, out_last);
+        };
+
+        template <typename InContainer, typename OutContainer>
+        void operator()(const InContainer& src, OutContainer& dest) {
+            operator()(src.cbegin(), src.cend(), dest.begin(), dest.end());
+        };
+
+        template <typename OutIter>
+        void operator()(std::ifstream& ifs, OutIter out_first,
+                        OutIter out_last) {
+            auto in_first = std::istreambuf_iterator<char>(ifs);
+            auto in_last = std::istreambuf_iterator<char>();
+            operator()(in_first, in_last, out_first, out_last);
+        };
+
+        template <typename OutCotainer>
+        void operator()(std::ifstream& ifs, OutCotainer& dest) {
+            operator()(ifs, dest.begin(), dest.end());
+        };
+
+        std::string get_hex_string() {
+            if(!is_finished_) {
+                throw std::runtime_error("Not finished!");
+            }
+            return bytes_to_hex_string(hash_);
+        };
+
+        template <typename InIter>
+        std::string get_hex_string(InIter in_first, InIter in_last) {
+            process(in_first, in_last);
+            finish();
+            auto hash = get_hex_string();
+            clear();
+            return hash;
+        };
+
+        template <typename InContainer>
+        std::string get_hex_string(const InContainer& src) {
+            return get_hex_string(src.cbegin(), src.cend());
+        };
+
+        std::string get_hex_string(std::ifstream& ifs) {
+            auto in_first = std::istreambuf_iterator<char>(ifs);
+            auto in_last = std::istreambuf_iterator<char>();
+            return get_hex_string(in_first, in_last);
+        };
+
+    private:
+        void clear_buffer() {
+            buffer_.fill(0);
+            buffer_pos_ = buffer_.begin();
+        };
+
+        void clear_state() {
+            for(auto& row : A_) {
+                row.fill(0);
+            }
+        };
+
+        void add_padding() {
+            const auto q =
+              buffer_.size() - std::distance(buffer_pos_, buffer_.begin());
+
+            if(padding_type == PaddingType::SHA) {
+                if(q == 1) {
+                    *buffer_pos_ = 0x86;
+                } else {
+                    *buffer_pos_ = 0x06;
+                    buffer_.back() = 0x80;
+                }
+            } else if(padding_type == PaddingType::SHAKE) {
+                if(q == 1) {
+                    *buffer_pos_ = 0x9F;
+                } else {
+                    *buffer_pos_ = 0x1F;
+                    buffer_.back() = 0x80;
+                }
+            }
+        };
+
+        void squeeze_() {
+            auto first = hash_.begin();
+            auto last = hash_.end();
+            first = squeeze(A_, first, last, rate_bytes);
+            while(first != last) {
+                keccak_p(A_);
+                first = squeeze(A_, first, last, rate_bytes);
+            }
+        };
+
+        std::array<byte_t, rate_bytes> buffer_;
+        typename decltype(buffer_)::iterator buffer_pos_;
+        state_t A_;
+        std::array<byte_t, d_bytes> hash_;
+        bool is_finished_;
+    };
+
+    template <size_t d_bits>
+    auto get_sha3_generator() {
+        static_assert(
+          d_bits == 224 || d_bits == 256 || d_bits == 384 || d_bits == 512,
+          "SHA3 only accepts digest message length 224, 256 384 or 512 bits.");
+        constexpr auto d_bytes = bits_to_bytes(d_bits);
+        constexpr auto capacity_bytes = d_bytes * 2;
+        constexpr auto rate_bytes = b_bytes - capacity_bytes;
+        return HashGenerator<rate_bytes, d_bytes, PaddingType::SHA>{};
+    }
+
+    template <size_t strength_bits, size_t d_bits>
+    auto get_shake_generator() {
+        static_assert(strength_bits == 128 or strength_bits == 256,
+                      "SHAKE only accepts strength 128 or 256 bits.");
+        constexpr auto strength_bytes = bits_to_bytes(strength_bits);
+        constexpr auto capacity_bytes = strength_bytes * 2;
+        constexpr auto rate_bytes = b_bytes - capacity_bytes;
+        constexpr auto d_bytes = bits_to_bytes(d_bits);
+        return HashGenerator<rate_bytes, d_bytes, PaddingType::SHAKE>{};
+    }
+
+} // namespace picosha3
+
+#endif


### PR DESCRIPTION
Local admin system that uses the SQLite db. Still work in progress.

Uses [picosha3](https://github.com/yawara/picosha3) (single cpp header file) for hashing the passwords with SHA3 and salts them with a user-configurable string.
To configure the salt, `<serverport>/.dbsalt`-file needs to be created with the salt inside.
I'm no security expert, this is the best I could come up with.

Commands:
```bash
adminlogin <password> # Log in as a local admin.
adminlogout # Log out as a local admin.
```

Proposed commands:
```bash
adminaddprivileges <username> <permissions> # Eg. adminaddprivileges Mehis mapchange kick voteban
adminremoveprivileges <username> <permissions> # Eg. adminremoveprivileges Mehis mapchange kick voteban

adminadd <username> <password> # Adds a new admin. Requires an admin with proper privileges.
adminremove <username> # Removes an admin. Requires an admin with proper privileges.

# And the usual actions you'd want to perform as an admin:
kick <username>
ban <username>
forcevote
# ...
```